### PR TITLE
Fix for TS when using noImplicitAny: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typescript",
     "utility"
   ],
+  "types": "pjson.d.ts",
   "typescript": {
     "definition": "pjson.d.ts"
   },


### PR DESCRIPTION
When using the noImplicitAny: true flag in tsconfig.json, the package issues an error on compile:
`error TS7016: Could not find a declaration file for module 'pjson'. '<app>/node_modules/pjson/pjson.js' implicitly has an 'any' type.`
Specifying the definition file with "types" in package.json fixes the issue.