### PR TITLE
fix root path in windows enviroments

### DIFF
--- a/pjson.js
+++ b/pjson.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
-var root = __dirname.replace('node_modules/pjson', '');
+var path = require('path');
+var root = path.resolve(__dirname, "..", "..");
 var contents = fs.readFileSync(root + '/package.json');
 var pjson = {};
 


### PR DESCRIPTION
In Windows a node path contains backslashes instead of slashes.
`__dirname.replace('node_modules/pjson', '');` is not working in that case.